### PR TITLE
Fix textarea wrap

### DIFF
--- a/html/style.css
+++ b/html/style.css
@@ -12,7 +12,7 @@ body, textarea {
 }
 
 textarea {
-    white-space: nowrap;
+    white-space: pre;
     font-size: 1.2em;
     min-width: 340px;
     width: auto;


### PR DESCRIPTION
- fix entire content displayed in one line in Firefox
- pre preserves amount of whitespace

before:
![image](https://user-images.githubusercontent.com/1851369/70440015-890afc00-1a91-11ea-9fd2-6f6612d1a079.png)

after:
![image](https://user-images.githubusercontent.com/1851369/70440020-8e684680-1a91-11ea-8b41-e9ab3643083b.png)
